### PR TITLE
Add searchable dropdowns

### DIFF
--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -123,6 +123,9 @@ testInitHappyPath =
                             , tenureDropdown = Dropdown.initialState
                             , careers_updated = "1999-01-01"
                             , countries_updated = "2000-01-01"
+                            , countrySearchTerm = ""
+                            , roleSearchTerm = ""
+                            , tenureSearchTerm = ""
                             }
         )
 
@@ -200,6 +203,9 @@ testInitQueryString =
                             , tenureDropdown = Dropdown.initialState
                             , careers_updated = "1999-01-01"
                             , countries_updated = "2000-01-01"
+                            , countrySearchTerm = ""
+                            , roleSearchTerm = ""
+                            , tenureSearchTerm = ""
                             }
         )
 
@@ -280,6 +286,9 @@ testInitInvalidQueryString =
                             , tenureDropdown = Dropdown.initialState
                             , careers_updated = "1999-01-01"
                             , countries_updated = "2000-01-01"
+                            , countrySearchTerm = ""
+                            , roleSearchTerm = ""
+                            , tenureSearchTerm = ""
                             }
         )
 
@@ -324,6 +333,9 @@ testInitMissingCountries =
                             , tenureDropdown = Dropdown.initialState
                             , careers_updated = "1970-01-01"
                             , countries_updated = "1970-01-01"
+                            , countrySearchTerm = ""
+                            , roleSearchTerm = ""
+                            , tenureSearchTerm = ""
                             }
         )
 
@@ -373,6 +385,9 @@ testInitMissingCareers =
                             , tenureDropdown = Dropdown.initialState
                             , careers_updated = "1970-01-01"
                             , countries_updated = "1970-01-01"
+                            , countrySearchTerm = ""
+                            , roleSearchTerm = ""
+                            , tenureSearchTerm = ""
                             }
         )
 
@@ -427,6 +442,9 @@ testInitMissingRoles =
                             , tenureDropdown = Dropdown.initialState
                             , careers_updated = "1970-01-01"
                             , countries_updated = "1970-01-01"
+                            , countrySearchTerm = ""
+                            , roleSearchTerm = ""
+                            , tenureSearchTerm = ""
                             }
         )
 
@@ -470,6 +488,9 @@ testInitInvalidConfig =
                             , tenureDropdown = Dropdown.initialState
                             , careers_updated = "1970-01-01"
                             , countries_updated = "1970-01-01"
+                            , countrySearchTerm = ""
+                            , roleSearchTerm = ""
+                            , tenureSearchTerm = ""
                             }
         )
 
@@ -630,6 +651,9 @@ hideWarnings =
                     , tenureDropdown = Dropdown.initialState
                     , careers_updated = "1970-01-01"
                     , countries_updated = "1970-01-01"
+                    , countrySearchTerm = ""
+                    , roleSearchTerm = ""
+                    , tenureSearchTerm = ""
                     }
                     |> Tuple.first
                     |> .warnings
@@ -650,6 +674,9 @@ hideWarnings =
                     , tenureDropdown = Dropdown.initialState
                     , careers_updated = "1970-01-01"
                     , countries_updated = "1970-01-01"
+                    , countrySearchTerm = ""
+                    , roleSearchTerm = ""
+                    , tenureSearchTerm = ""
                     }
                     |> Tuple.first
                     |> .warnings


### PR DESCRIPTION
Ref: https://github.com/teamniteo/ops/issues/1403

All three dropdowns are now searchable.
Example:

<img width="898" height="244" alt="Screenshot 2025-09-03 at 09 08 45" src="https://github.com/user-attachments/assets/67c0f9d9-3d65-422a-bddd-b4a6cf738fe6" />
<img width="899" height="369" alt="Screenshot 2025-09-03 at 09 09 11" src="https://github.com/user-attachments/assets/5f0e6260-5dd0-41d4-be8f-0e4b5b0efbd4" />
<img width="913" height="328" alt="Screenshot 2025-09-03 at 09 10 39" src="https://github.com/user-attachments/assets/304dde7d-7bee-40a8-a6ba-7bc0a63d27a5" />
